### PR TITLE
Remove incorrect architectures field from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,4 @@ paragraph= This library allows an Arduino/Genuino board to read LiquidCrystal MQ
 category= Sensors
 url=https://github.com/miguel5612/MQSensorsLib
 architectures=*
-architectures=avr
 license=MIT


### PR DESCRIPTION
Previously, there were two `architectures` fields. The first correctly identified the library as being for all architectures. The second incorrectly identified the library as being for `avr` architecture only. The second field overrides the value of the first field. For this reason, I have removed the incorrect second `architectures` field.