### PR TITLE
Update smokeDetector.ino

### DIFF
--- a/examples/smokeDetector/smokeDetector.ino
+++ b/examples/smokeDetector/smokeDetector.ino
@@ -89,7 +89,7 @@ void setup() {
   //Lecture will be saved in lecture variable
   MQ4.update();
   float smokePPM = MQ4.readSensor(); // Sensor will read PPM concentration using the model and a and b values setted before or in the setup
-  if(smokePPM > 1000) {Serial.println("Warning: High concentrations of smoke detected")};
+  if(smokePPM > 1000) {Serial.println("Warning: High concentrations of smoke detected");}
   MQ4.serialDebug(); // Will print the table on the serial port
   delay(400);  
 }


### PR DESCRIPTION


# Description
Semi colon before the curly bracket.

Fixes # (issue)
Semi colon has been moved before the curly bracket in line number 92 in examples/smokeDetector/smokeDetector.ino

## Type of change

Please delete options that are not relevant.

- [  ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the examples that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] MQ-3
- [  ] MQ-4
- [ ] MQ-5
- [ ] MQ-6
- [ ] MQ-7
- [ ] MQ-8
- [ ] MQ-9
- [ ] MQ-131
- [ ] MQ-135
- [ ] MQ-303
- [ ] MQ-309
- [ ] ESP8266
- [ ] ESP-32

**Test Configuration**:
* Board: Arduino Uno
* Software (Version of your arduino): 1.8.13
* Result (Good - Medium - Bad):
* Your Comments: Nothing


