### PR TITLE
Cleanup general definitions in MQUnifiedSensor.h

### DIFF
--- a/src/MQUnifiedsensor.cpp
+++ b/src/MQUnifiedsensor.cpp
@@ -1,5 +1,8 @@
 #include "MQUnifiedsensor.h"
 
+#define retries 2
+#define retry_interval 20
+
 MQUnifiedsensor::MQUnifiedsensor(String Placa, float Voltage_Resolution, int ADC_Bit_Resolution, int pin, String type) {
   this->_pin = pin;
   Placa.toCharArray(this->_placa, 20);

--- a/src/MQUnifiedsensor.h
+++ b/src/MQUnifiedsensor.h
@@ -6,10 +6,6 @@
 
 /***********************Software Related Macros************************************/
 
-#define ADC_RESOLUTION 10 // for 10bit analog to digital converter.
-#define retries 2
-#define retry_interval 20
-
 class MQUnifiedsensor
 {
   public:


### PR DESCRIPTION
# Description

Remove ADC_RESOLUTION and move retries and retry_interval to MQUnifiedsensor.cpp. These three definitions have generic names so it's easy to have them conflict with a user's sketch that imports MQUnifiedSensor.h.

ADC_RESOLUTION is unused, and retries and retry_interval are only used by getVoltage().

Fixes #60.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Build examples on Arduino IDE 1.8.19. This PR doesn't change any behavior of the library.