### PR TITLE
Allow setting the ADC pin of a MQUnifiedsensor object.

### DIFF
--- a/src/MQUnifiedsensor.cpp
+++ b/src/MQUnifiedsensor.cpp
@@ -41,6 +41,9 @@ void MQUnifiedsensor::setVoltResolution(float voltage_resolution)
 {
   _VOLT_RESOLUTION = voltage_resolution;
 }
+void MQUnifiedsensor::setPin(int pin) {
+  this->_pin = pin;
+}
 void MQUnifiedsensor::setRegressionMethod(int regressionMethod)
 {
   //this->_regressionMethod = regressionMethod;

--- a/src/MQUnifiedsensor.h
+++ b/src/MQUnifiedsensor.h
@@ -22,6 +22,7 @@ class MQUnifiedsensor
     void setB(float b);
     void setRegressionMethod(int regressionMethod);
     void setVoltResolution(float voltage_resolution =  5);
+    void setPin(int pin = 1);
     void serialDebug(bool onSetup = false); //Show on serial port information about sensor
     void setADC(int value); //For external ADC Usage
     
@@ -47,7 +48,7 @@ class MQUnifiedsensor
 
   private:
     /************************Private vars************************************/
-    byte _pin;
+    byte _pin = 1;
     byte _firstFlag = false;
     float _VOLT_RESOLUTION  = 5.0; // if 3.3v use 3.3
     float _RL = 10; //Value in KiloOhms


### PR DESCRIPTION
# Description

The ADC pin can only be set when using the full/long constructor, causing the short constructor (name/type only) useless because the pin is unset.

Also default the ADC pin to 1 for consistency sake.

Fixes #63.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Successfully ran the MQ-135 example with the following changes:

* constructor changed to `MQUnifiedsensor MQ135(placa, type)`
* added `MQ135.setPin(pin)` to `setup()`
 
Tests performed on Arduino IDE 1.8.19 with Arduino Nano and a MQ135 sensor.