### PR TITLE
Fix voltage resolution side effect

### DIFF
--- a/src/MQUnifiedsensor.cpp
+++ b/src/MQUnifiedsensor.cpp
@@ -142,10 +142,11 @@ float MQUnifiedsensor::validateEcuation(float ratioInput)
 float MQUnifiedsensor::readSensor(bool isMQ303A, float correctionFactor, bool injected)
 {
   //More explained in: https://jayconsystems.com/blog/understanding-a-gas-sensor
+  float voltRes = _VOLT_RESOLUTION; // preserve global resolution
   if(isMQ303A) {
-    _VOLT_RESOLUTION = _VOLT_RESOLUTION - 0.45; //Calculations for RS using mq303a sensor look wrong #42
+    voltRes = voltRes - 0.45; //Calculations for RS using mq303a sensor look wrong #42
   }
-  _RS_Calc = ((_VOLT_RESOLUTION*_RL)/_sensor_volt)-_RL; //Get value of RS in a gas
+  _RS_Calc = ((voltRes*_RL)/_sensor_volt)-_RL; //Get value of RS in a gas
   if(_RS_Calc < 0)  _RS_Calc = 0; //No negative values accepted.
   if(!injected) _ratio = _RS_Calc / this->_R0;   // Get ratio RS_gas/RS_air
   _ratio += correctionFactor;


### PR DESCRIPTION
## Summary
- prevent MQ303A adjustments from altering global voltage resolution

## Testing
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: no rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6840c6085234832fa4dc61e534043f92